### PR TITLE
try to fix selector background

### DIFF
--- a/styles/bazaar.css
+++ b/styles/bazaar.css
@@ -1,27 +1,83 @@
-.config-account__cover{background-image:none !important}
+.config-account__cover {
+  background-image: none !important
+}
 
-.config-bazaar__readme .item__side{border-right: 2px dashed var(--b3-theme-surface-lighter);}
-#configBazaarReadme.config-bazaar__readme{
+.config-bazaar__readme .item__side {
+  border-right: 2px dashed var(--b3-theme-surface-lighter);
+}
+
+#configBazaarReadme.config-bazaar__readme {
   z-index: 3;
 }
-.b3-card {
-    box-shadow:unset;
-    border:1px solid var(--b3-border-color);
-}
-.counter.fn__flex-center.b3-tooltips.b3-tooltips__w,.block__icons .counter{background-color: var(--b3-theme-primary) !important;color:var(--b3-theme-on-primary)}
-.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container{background-color:#2d2d2d4a}
-[data-key="⌘P"] .b3-dialog__container{background-color:var(--b3-theme-surface) !important}
-.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .b3-text-field{background-color:transparent}
-.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .layout-tab-bar .item,.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .layout-tab-bar .item--full,.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .layout-tab-bar{background-color:transparent !important}
-.config__tab-wrap{background-color:#1212123d}
 
-.config__panel>.b3-tab-bar{
-   background-color:#0000004a;
-   border-radius:12px 0 0px 12px;
+.b3-card {
+  box-shadow: unset;
+  border: 1px solid var(--b3-border-color);
 }
-.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .b3-select:hover,.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .b3-select,.b3-card{background-color:transparent !important}
-.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .layout-tab-bar{border-bottom:none}
-.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .layout-tab-bar .item--full .item__text:after{display:block;content:"";background-color:transparent;border-radius: 12px;height: 3px;width:100%;margin-top:5px}
-.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .layout-tab-bar .item--full .item__text{margin-top:5px}
-.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .layout-tab-bar .item--full.item--focus .item__text:after{background-color:var(--b3-theme-primary);transition:all 300ms}
-.config-account__center--text,.history__repo{background-color:transparent}
+
+.counter.fn__flex-center.b3-tooltips.b3-tooltips__w,
+.block__icons .counter {
+  background-color: var(--b3-theme-primary) !important;
+  color: var(--b3-theme-on-primary)
+}
+
+.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container {
+  background-color: #2d2d2d4a
+}
+
+[data-key="⌘P"] .b3-dialog__container {
+  background-color: var(--b3-theme-surface) !important
+}
+
+.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .b3-text-field {
+  background-color: transparent
+}
+
+.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .layout-tab-bar .item,
+.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .layout-tab-bar .item--full,
+.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .layout-tab-bar {
+  background-color: transparent !important
+}
+
+.config__tab-wrap {
+  background-color: #1212123d
+}
+
+.config__panel > .b3-tab-bar {
+  background-color: #0000004a;
+  border-radius: 12px 0 0px 12px;
+}
+
+.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .b3-select:hover,
+.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .b3-select,
+.b3-card {
+  background-color: var(--b3-select-background);
+}
+
+.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .layout-tab-bar {
+  border-bottom: none
+}
+
+.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .layout-tab-bar .item--full .item__text:after {
+  display: block;
+  content: "";
+  background-color: transparent;
+  border-radius: 12px;
+  height: 3px;
+  width: 100%;
+  margin-top: 5px
+}
+
+.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .layout-tab-bar .item--full .item__text {
+  margin-top: 5px
+}
+
+.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .layout-tab-bar .item--full.item--focus .item__text:after {
+  background-color: var(--b3-theme-primary);
+  transition: all 300ms
+}
+
+.config-account__center--text,
+.history__repo {
+  background-color: transparent
+}

--- a/styles/bazaar.css
+++ b/styles/bazaar.css
@@ -48,11 +48,11 @@
   border-radius: 12px 0 0px 12px;
 }
 
-.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .b3-select:hover,
+/* .b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .b3-select:hover,
 .b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .b3-select,
 .b3-card {
   background-color: var(--b3-select-background);
-}
+} */
 
 .b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .layout-tab-bar {
   border-bottom: none


### PR DESCRIPTION
尝试修复了选择框背景问题#6，这次更改是对
```css
.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .b3-select:hover,
.b3-dialog:has(.b3-dialog__scrim) .b3-dialog__container .b3-select,
.b3-card
```
作修改，<del>改为`background: var(-b3-select-background)`，</del>直接注释掉这段css保证正常显示
这是在思源开发者工具中找到的css标签，并且改为禁用主题更改后计算得出的默认显示方案，能正常解决问题，但是不保证不会影响其他内容（但是估计也没什么问题）
因为原源文件未格式化原因，文件被格式化导致修改内容看起来很多，这是正常情况